### PR TITLE
Remove the integration with opsmill/infrahub repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,15 +11,6 @@
       "python.venvPath": "/workspace/.venv",
       "python.linting.enabled": true
     },
-    "codespaces": {
-      "repositories": {
-        "opsmill/infrahub": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "pomdtr.excalidraw-editor",


### PR DESCRIPTION
Unless I'm mistaken, I don't think this is required anymore