### PR TITLE
Fix to get_configs.py incorrectly calling InfrahubClientSync

### DIFF
--- a/scripts/get_configs.py
+++ b/scripts/get_configs.py
@@ -9,7 +9,7 @@ def get_containerlab_topology():
     if not os.path.exists(directory_path):
         os.makedirs(directory_path)
 
-    client = InfrahubClientSync.init()
+    client = InfrahubClientSync()
     topologies = client.all(kind="TopologyTopology")
 
     for topology in topologies:
@@ -22,7 +22,7 @@ def get_device_configs():
     if not os.path.exists(directory_path):
         os.makedirs(directory_path)
 
-    client = InfrahubClientSync.init()
+    client = InfrahubClientSync()
     devices = client.all(kind="InfraDevice")
 
     for device in devices:


### PR DESCRIPTION
Fix to:

$ poetry run python3 scripts/get_configs.py
Traceback (most recent call last):
  File "/home/dhoutz/infrahub/infrahub-demo-dc-fabric/scripts/get_configs.py", line 38, in <module>
    get_containerlab_topology()
  File "/home/dhoutz/infrahub/infrahub-demo-dc-fabric/scripts/get_configs.py", line 12, in get_containerlab_topology
    client = InfrahubClientSync.init()
             ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'InfrahubClientSync' has no attribute 'init'