### PR TITLE
Fix path for docs copy

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Sync folders
         run: |
-          rm -rf target-repo/docs/docs/*
-          cp -r source-repo/docs/docs/* target-repo/docs/docs/
+          rm -rf target-repo/docs/docs-demo/*
+          cp -r source-repo/docs/docs/* target-repo/docs/docs-demo/
           cd target-repo
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Sync folders
         run: |
-          rm -rf target-repo/docs/docs-infrahub/*
-          cp -r source-repo/docs/docs/* target-repo/docs/docs-infrahub/
+          rm -rf target-repo/docs/docs/*
+          cp -r source-repo/docs/docs/* target-repo/docs/docs/
           cd target-repo
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
I put an incorrect path to copy the docs to the target repo `infrahub-docs`